### PR TITLE
Suggested Edits To README.md + Docker Compose After Testing On Hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ To run
 ```bash
 docker compose up
 # Open a new terminal window and run:
-docker attach franka_ros-main-1
+docker attach <your-repo-name>-main-1
 ```
+where `<your-repo-name>` is the name that you choose for the new repository (i.e., the repository that uses this template).
 
 Now you should have access to the full Franka ROS interface documented [`here`](https://frankaemika.github.io/docs/franka_ros.html).
 
@@ -23,7 +24,7 @@ For example, you can test the connection to the robot as follows:
 1. Go to the [Desk webapp](https://172.16.0.2/desk/) and login.
 2. Unlock the robot using the sidebar on the right of the screen.
 3. Open the drop-down in the top right by clicking on the IP address, then click "Activate FCI" to enable the Franka Control Interface.
-4. Run the docker container using `docker compose run franka`
+4. Run the docker container using `docker compose run main`
 5. Run the command `roslaunch franka_example_controllers joint_impedance_example_controller.launch   robot_ip:=$FCI_IP load_gripper:=true robot:=fr3`
 
 The robot should move in a circle, and an RViz window should open showing a matching 3D model of the robot.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,20 +10,20 @@ services:
     tty: true        # docker run -t
     command: roscore
 
-  cartesian_impedance_control:
-    image: franka_ros:latest
-    build: .docker
-    environment:
-      - DISPLAY=${DISPLAY}
-    volumes:
-      - /tmp/.X11-unix:/tmp/.X11-unix
-    network_mode: host
-    privileged: true
-    stdin_open: true # docker run -i
-    tty: true        # docker run -t
-    depends_on:
-      - roscore
-    command: /bin/bash -c '. /catkin_ws/devel/setup.bash && roslaunch --wait franka_example_controllers cartesian_impedance_example_controller_no_marker.launch robot:=fr3 robot_ip:=172.16.0.2 load_gripper:=True'
+  # cartesian_impedance_control:
+  #   image: franka_ros:latest
+  #   build: .docker
+  #   environment:
+  #     - DISPLAY=${DISPLAY}
+  #   volumes:
+  #     - /tmp/.X11-unix:/tmp/.X11-unix
+  #   network_mode: host
+  #   privileged: true
+  #   stdin_open: true # docker run -i
+  #   tty: true        # docker run -t
+  #   depends_on:
+  #     - roscore
+  #   command: /bin/bash -c '. /catkin_ws/devel/setup.bash && roslaunch --wait franka_example_controllers cartesian_impedance_example_controller_no_marker.launch robot:=fr3 robot_ip:=172.16.0.2 load_gripper:=True'
 
   main:
     image: franka_ros:latest
@@ -39,5 +39,5 @@ services:
     tty: true        # docker run -t
     depends_on:
       - roscore
-      - cartesian_impedance_control
+      # - cartesian_impedance_control
     command: bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,23 +7,23 @@ services:
     network_mode: host
     privileged: true
     stdin_open: true # docker run -i
-    tty: true        # docker run -t
+    tty: true # docker run -t
     command: roscore
 
-  # cartesian_impedance_control:
-  #   image: franka_ros:latest
-  #   build: .docker
-  #   environment:
-  #     - DISPLAY=${DISPLAY}
-  #   volumes:
-  #     - /tmp/.X11-unix:/tmp/.X11-unix
-  #   network_mode: host
-  #   privileged: true
-  #   stdin_open: true # docker run -i
-  #   tty: true        # docker run -t
-  #   depends_on:
-  #     - roscore
-  #   command: /bin/bash -c '. /catkin_ws/devel/setup.bash && roslaunch --wait franka_example_controllers cartesian_impedance_example_controller_no_marker.launch robot:=fr3 robot_ip:=172.16.0.2 load_gripper:=True'
+  cartesian_impedance_control:
+    image: franka_ros:latest
+    build: .docker
+    environment:
+      - DISPLAY=${DISPLAY}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    network_mode: host
+    privileged: true
+    stdin_open: true # docker run -i
+    tty: true # docker run -t
+    depends_on:
+      - roscore
+    command: /bin/bash -c '. /catkin_ws/devel/setup.bash && roslaunch --wait franka_example_controllers cartesian_impedance_example_controller_no_marker.launch robot:=fr3 robot_ip:=172.16.0.2 load_gripper:=True'
 
   main:
     image: franka_ros:latest
@@ -36,8 +36,7 @@ services:
     network_mode: host
     privileged: true
     stdin_open: true # docker run -i
-    tty: true        # docker run -t
+    tty: true # docker run -t
     depends_on:
       - roscore
-      # - cartesian_impedance_control
     command: bash


### PR DESCRIPTION
I changed the README.md and the Docker comose file in the following ways:
- Added repo-dependent name to the `docker attach` command used in README.md
- Changed the instructions in the `Dockerized Franka ROS Interface` section so that they reference correct container + commented out the `cartesian_impedance_control` container from docker-compose.yml.

If you want to know more...
- *I changed `docker-compose.yml`*: For some reason, it seems that the example `joint_impedance_example_controller.launch` has trouble launching when the `cartesian_impedance_control` container is running. I think this is being caused by `joint_impedance_example_controller.launch` creating identical ROS nodes and topics to what is already running inside of the `cartesian_impedance_control` container.
- An alternative solution to the conflict between `cartesian_impedance_control` and the demo script (I've also tested this):  The example in `Dockerized Franka ROS Interface` can run the `cartesian_impedance_control` container as a demo instead of the `main` container. Note that when running the `cartesian_impedance_control` container, no further action is required to start the demo (i.e., step 5 is not needed) because of how `cartesian_impedance_control` is defined.

This was meant to address issue #1 .